### PR TITLE
Add -march=armv8.1a by default on aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,8 @@ option(LOMP_ICC_SUPPORT "Build additional entry points for Intel classic compile
 option(LOMP_MICROBM_WITH_LOMP "Use LOMP for micro-benchmarks" OFF)
 option(LOMP_BUILD_MICROBM "Build micro-benchmarks" ON)
 option(LOMP_BUILD_EXAMPLES "Build example programs" ON)
-
+# Assume aarch64 v8.1a architecture by default.
+SET(LOMP_ARM64_ARCHITECTURE "armv8.1a" CACHE STRING "Detailed aarch64 architecture passed to -march=")
 include(CheckCXXCompilerFlag)
 
 # look for Git
@@ -51,6 +52,12 @@ message(STATUS "Target system: ${LOMP_TARGET_OS}")
 # Detect the machine architecture
 execute_process(COMMAND arch COMMAND tr -d '\n' OUTPUT_VARIABLE LOMP_TARGET_ARCH)
 message(STATUS "Architecture: ${LOMP_TARGET_ARCH}")
+
+if (${LOMP_TARGET_ARCH} STREQUAL "aarch64")
+   add_compile_options(-march=${LOMP_ARM64_ARCHITECTURE})
+   message("-- LOMP_ARM64_ARCHITECTURE=${LOMP_ARM64_ARCHITECTURE} => -march=${LOMP_ARM64_ARCHITECTURE}")
+   add_compile_definitions(LOMP_ARM64_ARCHITECTURE=${LOMP_ARM64_ARCHITECTURE})   
+endif()
 
 # find all LOMP source files
 file(GLOB_RECURSE LOMP_SOURCE_FILES ${PROJECT_SOURCE_DIR}/*.cc


### PR DESCRIPTION
We were not enabling the Arm v8.1a features in aarch64 by default, or allowing the user to do that (or, choose any other aarch64 dialects). This enables v8.1a by default, since that improves the code-generation for atomic operations.