### PR TITLE
Bugfix: libnuma was failing on RISC-V

### DIFF
--- a/src/numa_support.cc
+++ b/src/numa_support.cc
@@ -121,9 +121,6 @@ void InitializeNumaSupport() {
       if (numa_bitmask_isbitset(mask, c)) {
         CoresInDomain.push_back(c);
       }
-      else {
-        CoresInDomain.push_back(c);
-      }
     }
     CoresPerNumaDomain.push_back(CoresInDomain);
   }


### PR DESCRIPTION
On RISC-V libnuma is available, but does not seem to be fully
functional.  Thus, some of the calls reported undefined values and
produced an error when the runtime tried to detect the NUMA structure
of the RISC-V system.  Thus bugfix changes the detection code such
that it first determines if libnuma claims to work and if not falls
back to a single NUMA domain (like with systems w/o libnuma).