### PR TITLE
Fix two warnings.

### DIFF
--- a/src/entrypoints.cc
+++ b/src/entrypoints.cc
@@ -248,7 +248,7 @@ int32_t __kmpc_omp_task(ident_t *, // where
 
 void __kmpc_omp_task_begin_if0(ident_t *, // where
                                int32_t,   // gtid
-                               void * new_task) {
+                               void *     // new_task) {
   // Do nothing, as the task is invoked in the compiler-generated code.
 }
 

--- a/src/tasking.cc
+++ b/src/tasking.cc
@@ -419,19 +419,17 @@ void PrepareTask(TaskDescriptor * task) {
 }
 
 bool StoreTask(TaskDescriptor * task) {
-  auto thread = Thread::getCurrentThread();
-  auto team = thread->getTeam();
-  auto taskPool = thread->getTaskPool();
-  bool result = true;
-
+  auto taskPool = Thread::getCurrentThread()->getTaskPool();
+  
   // Try to put the task into the pool.
-  if (!taskPool->put(task)) {
+  if (taskPool->put(task)) {
+    return true;
+  } else {
     // There was no free slot in the task pool. Execute the task immediately,
     // to avoid a stall of execution.
     InvokeTask(task);
-    result = false;
+    return false;
   }
-  return result;
 }
 
 void FreeTask(TaskDescriptor * task) {


### PR DESCRIPTION
Fix two warnings in tasking code.
In `storeTask` I simplified the logic a little as well.
