### PR TITLE
Fix an issue with a deadlock for if(0) tasks

### DIFF
--- a/src/tasking.h
+++ b/src/tasking.h
@@ -12,7 +12,11 @@
 #include <atomic>
 #include <cstdint>
 
-namespace lomp::Tasking {
+namespace lomp {
+
+class Thread;
+
+namespace Tasking {
 
 typedef void (*GnuThunkPointer)(void *);
 typedef int32_t (*ThunkPointer)(int32_t, void *);
@@ -41,6 +45,7 @@ struct TaskDescriptor {
     /* task descriptor for task management */
     Flags flags;
     TaskDescriptor * parent; /* pointer to the parent that created this task */
+    Thread * thread; /* pointer to the thread that create the task */
     std::atomic<int>
         childTasks; /* number of child tasks to (potentially) wait for */
     Taskgroup * taskgroup;
@@ -83,6 +88,8 @@ bool TaskWait();
 void TaskgroupBegin();
 void TaskgroupEnd();
 
-} // namespace lomp::Tasking
+} // namespace Tasking
+
+} // namespace lomp
 
 #endif

--- a/src/threads.h
+++ b/src/threads.h
@@ -80,7 +80,7 @@ class ThreadTeam {
   std::atomic<uint64_t> NextSingle;
 
 public:
-  std::atomic<size_t> activeTasks;
+  std::atomic<ssize_t> activeTasks;
 
   ThreadTeam(int ThreadCount);
   auto getBarrier() const {


### PR DESCRIPTION
The issue was caused by the different counts for parent tasks, parent
threads (= implicit task in OpenMP lingo) was not maintained in the
right way.  This commit attempts to fix this.