### PR TITLE
Implement aligned memory allocation routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Version "next"
 * Feature: Implement a serial version of LOMP runtime.
 * Feature: Support static-library version of LOMP
+* Internal: use aligned allocations instead of regular malloc/free
 
 # Version 0.2
 * Feature: Add entrypoints for tasks with `if(0)` clause.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Version "next"
 * Feature: Implement a serial version of LOMP runtime.
 * Feature: Support static-library version of LOMP
-* Internal: use aligned allocations instead of regular malloc/free
+* Internal: use aligned allocations instead of regular malloc/free & new/delete
 
 # Version 0.2
 * Feature: Add entrypoints for tasks with `if(0)` clause.

--- a/README.md
+++ b/README.md
@@ -317,9 +317,10 @@ its behavior:
   * `2`: print informational messages.
   * `10`: print  more details.
   * `20`: print debugging messages for LOMP threading subsystems.
-  * `30`: print debugging messages for barriers.
-  * `40`: print debugging messages for loop scheduling.
-  * `50`: print debugging messages for lock implementations.
+  * `30`: print debugging message for memory allocations.
+  * `40`: print debugging messages for barriers.
+  * `50`: print debugging messages for loop scheduling.
+  * `60`: print debugging messages for lock implementations.
   * `1000`: print debugging messages for internal function invocations.
 * `LOMP_TRACE`: Enable LOMP's internal tracing facility, setting the debug
   level to the value specified for `LOMP_TRACE`.  See `LOMP_DEBUG` for the

--- a/src/barrier_impl.cc
+++ b/src/barrier_impl.cc
@@ -36,33 +36,6 @@
 #endif
 
 namespace lomp {
-// Derive publicly from this to force an aligned allocator to be used for the given object.
-// C++17 has better ways of doing this, but we're sticking to C++14...
-//template <intalignedAllocators alignment>
-//class  {
-//  static void * doAllocation(std::size_t bytes) {
-//    void * res;
-//    res = std::aligned_alloc(alignment, bytes);
-//    if (!res) {
-//      fatalError("Aligned memory allocation failed.");
-//    }
-//    return res;
-//  }
-//
-//public:
-//  static void * operator new[](std::size_t bytes) {
-//    return doAllocation(bytes);
-//  }
-//  static void * operator new(std::size_t bytes) {
-//    return doAllocation(bytes);
-//  }
-//  static void operator delete[](void * space) {
-//    free(space);
-//  }
-//  static void operator delete(void * space) {
-//    free(space);
-//  }
-//};
 
 // Be careful with these. They force the individual item to be cache-aligned and padded to the size of the cacheline.
 // If you want a single uint32 aligned at the start of a line with other data following it, DO NOT USE THIS!

--- a/src/barrier_impl.cc
+++ b/src/barrier_impl.cc
@@ -29,6 +29,7 @@
 #include "barriers.h"
 #include "target.h"
 #include "debug.h"
+#include "memory.h"
 
 #if (DEBUG > 0)
 #include <sstream>
@@ -37,36 +38,36 @@
 namespace lomp {
 // Derive publicly from this to force an aligned allocator to be used for the given object.
 // C++17 has better ways of doing this, but we're sticking to C++14...
-template <int alignment>
-class alignedAllocators {
-  static void * doAllocation(std::size_t bytes) {
-    void * res;
-    res = std::aligned_alloc(alignment, bytes);
-    if (!res) {
-      fatalError("Aligned memory allocation failed.");
-    }
-    return res;
-  }
-
-public:
-  static void * operator new[](std::size_t bytes) {
-    return doAllocation(bytes);
-  }
-  static void * operator new(std::size_t bytes) {
-    return doAllocation(bytes);
-  }
-  static void operator delete[](void * space) {
-    free(space);
-  }
-  static void operator delete(void * space) {
-    free(space);
-  }
-};
+//template <intalignedAllocators alignment>
+//class  {
+//  static void * doAllocation(std::size_t bytes) {
+//    void * res;
+//    res = std::aligned_alloc(alignment, bytes);
+//    if (!res) {
+//      fatalError("Aligned memory allocation failed.");
+//    }
+//    return res;
+//  }
+//
+//public:
+//  static void * operator new[](std::size_t bytes) {
+//    return doAllocation(bytes);
+//  }
+//  static void * operator new(std::size_t bytes) {
+//    return doAllocation(bytes);
+//  }
+//  static void operator delete[](void * space) {
+//    free(space);
+//  }
+//  static void operator delete(void * space) {
+//    free(space);
+//  }
+//};
 
 // Be careful with these. They force the individual item to be cache-aligned and padded to the size of the cacheline.
 // If you want a single uint32 aligned at the start of a line with other data following it, DO NOT USE THIS!
-class AlignedUint32 : public alignedAllocators<CACHELINE_SIZE> {
-  alignas(CACHELINE_SIZE) uint32_t Value;
+class AlignedUint32 : private memory::CacheAligned {
+  alignas(CacheAligned::alignment) uint32_t Value;
 
 public:
   AlignedUint32(uint32_t v) : Value(v) {}
@@ -77,10 +78,12 @@ public:
   uint32_t operator++(int) {
     return Value++;
   }
+  using CacheAligned::operator new;
+  using CacheAligned::operator delete;
 };
 
-class AlignedAtomicUint32 : public alignedAllocators<CACHELINE_SIZE> {
-  alignas(CACHELINE_SIZE) std::atomic<uint32_t> Value;
+class AlignedAtomicUint32 : private memory::CacheAligned {
+  alignas(CacheAligned::alignment) std::atomic<uint32_t> Value;
 
 public:
   AlignedAtomicUint32(uint32_t v) : Value(v) {}
@@ -97,6 +100,8 @@ public:
   uint32_t operator++(int) {
     return Value.fetch_add(1);
   }
+  using CacheAligned::operator new;
+  using CacheAligned::operator delete;
 };
 
 // A simple broadcast operation in which all worker threads poll the
@@ -107,7 +112,7 @@ public:
 // We need a separate class to encapsulate waiting, but that will come later.
 // Similarly it won't execute tasks, which needs to be inside the waiting class.
 //
-class NaiveBroadcast : public alignedAllocators<CACHELINE_SIZE> {
+class NaiveBroadcast : private memory::CacheAligned {
   // Put the payload and the flag into the same cache line.
   CACHE_ALIGNED std::atomic<uint32_t> Flag;
   InvocationInfo const * OutlinedBody;
@@ -145,6 +150,8 @@ public:
     NextValues[me] = ~NextFlag;
     return OutlinedBody;
   }
+  using CacheAligned::operator new;
+  using CacheAligned::operator delete;
 };
 
 // A broadcast which uses a specific fan-out per cacheline. I'd expect
@@ -159,16 +166,20 @@ public:
 // to two sets of flags and a reset, though, since we couldn't do up/down
 // easily.
 template <int LBW>
-class LBWBroadcast : public alignedAllocators<CACHELINE_SIZE> {
+class LBWBroadcast : private memory::CacheAligned {
   // Shared data, sitting in a single line, we hope.
-  struct flagLine : public alignedAllocators<CACHELINE_SIZE> {
-    alignas(CACHELINE_SIZE) std::atomic<uint32_t> Flag;
+  struct flagLine : private memory::CacheAligned {
+    alignas(CacheAligned::alignment) std::atomic<uint32_t> Flag;
     InvocationInfo const * OutlinedBody;
+    using CacheAligned::operator new;
+    using CacheAligned::operator delete;
   } * goFlags;
   AlignedUint32 * NextValues;
   int NumThreads;
 
 public:
+  using CacheAligned::operator new;
+  using CacheAligned::operator delete;
   LBWBroadcast(int nThreads) : NumThreads(nThreads) {
     goFlags = new flagLine[(NumThreads + LBW - 1) / LBW];
     for (int i = 0; i < (NumThreads + LBW - 1) / LBW; i++) {
@@ -285,7 +296,7 @@ class flagCounter {
     std::atomic<uint8_t> flags[8];
   } byteWord;
   enum { numEntries = (maxCount + 7) / 8, lastEntry = numEntries - 1 };
-  alignas(CACHELINE_SIZE) byteWord data[numEntries];
+  alignas(memory::CacheAligned::alignment) byteWord data[numEntries];
   // The last word may not need all of the bytes, so we initialize
   // it so that entries which don't exist appear present.
   // That avoids a special case in the polling loop.
@@ -487,12 +498,14 @@ public:
 
 // A barrier in which threads count up or down, polling the appropriate counter.
 class AtomicUpDownBarrier : public Barrier,
-                            public alignedAllocators<CACHELINE_SIZE> {
+                            private memory::CacheAligned {
   enum { MAX_THREADS = 64 };
   AtomicUpDownCounter counters[2];
   AlignedUint32 barrierCounts[MAX_THREADS];
 
 public:
+  using CacheAligned::operator new;
+  using CacheAligned::operator delete;
   AtomicUpDownBarrier(int NumThreads) {
     for (int i = 0; i < NumThreads; i++) {
       barrierCounts[i] = 0;
@@ -847,11 +860,13 @@ public:
  */
 template <class counter, class broadcast, char const * fullName>
 class centralizedBarrier : public Barrier,
-                           public alignedAllocators<CACHELINE_SIZE> {
+                           private memory::CacheAligned {
   counter CheckedIn;
   broadcast Broadcast;
 
 public:
+  using CacheAligned::operator new;
+  using CacheAligned::operator delete;
   centralizedBarrier(int NumThreads)
       : CheckedIn(NumThreads), Broadcast(NumThreads) {}
 
@@ -994,13 +1009,15 @@ FOREACH_DYNAMICTREE_BARRIER(EXPAND_DYNAMICTREE_BARRIER, LBWBroadcast<4>, LBW4)
 // We could equally make this into a template and use our other, flag
 // counter here, though that would make the barrier quite large.
 class AllToAllAtomicBarrier : public Barrier,
-                              public alignedAllocators<CACHELINE_SIZE> {
+                              private memory::CacheAligned {
   enum { MAX_THREADS = 64 };
   uint32_t NumThreads;
   AlignedAtomicUint32 flags[2][MAX_THREADS];
   AlignedUint32 sequence[MAX_THREADS];
 
 public:
+  using CacheAligned::operator new;
+  using CacheAligned::operator delete;
   AllToAllAtomicBarrier(int NThreads) : NumThreads(NThreads) {
     LOMP_ASSERT(NumThreads <= MAX_THREADS);
     for (uint32_t i = 0; i < NumThreads; i++) {
@@ -1058,7 +1075,7 @@ public:
 // Or, probably others too.
 template <int radix>
 class distributedLogBarrier : public Barrier,
-                              public alignedAllocators<CACHELINE_SIZE> {
+                              private memory::CacheAligned {
 
   // We want the derived class to be able to see into here since it
   // needs access to things like the number of threads and rounds.
@@ -1099,6 +1116,8 @@ protected:
   }
 
 public:
+  using CacheAligned::operator new;
+  using CacheAligned::operator delete;
   distributedLogBarrier(int nThreads) : NumThreads(nThreads) {
     NumRounds = ceilingLogN(radix, NumThreads);
     debug(Debug::Barriers, "distributedLogBarrier<%d> %d: %d rounds", radix,
@@ -1160,7 +1179,7 @@ class DisseminationBarrier : public distributedLogBarrier<2> {
 
 public:
   DisseminationBarrier(int numThreads) : distributedLogBarrier(numThreads) {
-    // Now add the commnication pattern which calls back to our "neighbour"
+    // Now add the communication pattern which calls back to our "neighbour"
     // method.
     computeCommunication();
   }

--- a/src/debug.h
+++ b/src/debug.h
@@ -41,9 +41,10 @@ enum Debug {
   // Switch around when debugging specific subsystems so that you can get info from only the subsystem you want.
   Reduction = 15,
   Threads = 20,
-  Barriers = 30,
-  Loops = 40,
-  Locks = 50,
+  MemoryAllocation = 30,
+  Barriers = 40,
+  Loops = 50,
+  Locks = 60,
   Functions = 1000,
 };
 

--- a/src/locks.cc
+++ b/src/locks.cc
@@ -38,7 +38,7 @@ namespace lomp::locks {
 // Note that this meets the requirements of the C++ "Lockable"
 // https://en.cppreference.com/w/cpp/named_req/Lockable ;
 // therefore it can be used behind std::lock_guard if required.
-class abstractLock {
+class abstractLock {  // TODO: should this be aligned to a cache line?
 public:
   abstractLock() {}
   virtual ~abstractLock() {}

--- a/src/memory.h
+++ b/src/memory.h
@@ -15,40 +15,41 @@
 
 namespace lomp::memory {
 
-template<typename AllocType>
-AllocType * aligned_alloc(size_t alignment = CACHELINE_SIZE) {
-  return new (std::align_val_t(alignment)) AllocType{};
+template<typename AllocType, typename... Args>
+inline AllocType * make_aligned(Args&&... args) {
+  fprintf(stderr, "called %s at %s:%d\n", __FUNCTION__, __FILE__, __LINE__);
+  return new (std::align_val_t(CACHELINE_SIZE)) AllocType(std::forward<Args>(args)...);
+}
+
+template<typename AllocType, typename... Args>
+inline AllocType * make_aligned_struct(Args&&... args) {
+  fprintf(stderr, "called %s at %s:%d\n", __FUNCTION__, __FILE__, __LINE__);
+  return new (std::align_val_t(CACHELINE_SIZE)) AllocType{std::forward<Args>(args)...};
+}
+
+inline void * make_aligned_chunk(size_t size) {
+  fprintf(stderr, "called %s at %s:%d\n", __FUNCTION__, __FILE__, __LINE__);
+  return new (std::align_val_t(CACHELINE_SIZE)) char[size];
 }
 
 template<typename AllocType>
-AllocType * aligned_alloc_array(size_t size, size_t alignment = CACHELINE_SIZE) {
-  printf("in %s\n", __FUNCTION__ );
-  return new (std::align_val_t(alignment)) AllocType[size];
-}
-
-void * aligned_alloc_chunk(size_t size, size_t alignment = CACHELINE_SIZE) {
-  printf("in %s\n", __FUNCTION__ );
-  return new (std::align_val_t(alignment)) char[size];
-}
-
-template<typename AllocType>
-AllocType * aligned_free(AllocType * ptr) {
-  printf("in %s\n", __FUNCTION__ );
+inline void delete_aligned(AllocType * ptr) {
+  fprintf(stderr, "called %s at %s:%d\n", __FUNCTION__, __FILE__, __LINE__);
   delete ptr;
 }
 
 template<typename AllocType>
-AllocType * aligned_free_array(AllocType * ptr) {
-  printf("in %s\n", __FUNCTION__ );
-  delete[] ptr;
+inline void delete_aligned_struct(AllocType * ptr) {
+  fprintf(stderr, "called %s at %s:%d\n", __FUNCTION__, __FILE__, __LINE__);
+  delete ptr;
 }
 
-void aligned_free_chunk(void * ptr) {
-  printf("in %s\n", __FUNCTION__ );
-  auto * chunk =reinterpret_cast<char *>(ptr);
+inline void delete_aligned_chunk(void * ptr) {
+  fprintf(stderr, "called %s at %s:%d\n", __FUNCTION__, __FILE__, __LINE__);
+  auto * chunk = reinterpret_cast<char *>(ptr);
   delete[] chunk;
 }
 
-}
+} // namespace lomp::memory
 
 #endif //LOMP_MEMORY_H

--- a/src/memory.h
+++ b/src/memory.h
@@ -50,6 +50,18 @@ inline void delete_aligned_chunk(void * ptr) {
   delete[] chunk;
 }
 
+struct CacheAligned {
+    void * operator new(std::size_t sz) {
+      fprintf(stderr, "new at %s:%d\n", __FILE__, __LINE__);
+      return make_aligned_chunk(sz);
+    }
+
+    void operator delete(void * ptr) {
+      fprintf(stderr, "delete at %s:%d\n", __FILE__, __LINE__);
+      delete_aligned_chunk(ptr);
+    }
+};
+
 } // namespace lomp::memory
 
 #endif //LOMP_MEMORY_H

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,0 +1,50 @@
+//
+// Created by micha on 19.02.2022.
+//
+
+#ifndef LOMP_MEMORY_H
+#define LOMP_MEMORY_H
+
+#include "target.h"
+
+#include <new>
+
+namespace lomp::memory {
+
+template<typename AllocType>
+AllocType * aligned_alloc(size_t alignment = CACHELINE_SIZE) {
+  return new (std::align_val_t(alignment)) AllocType{};
+}
+
+template<typename AllocType>
+AllocType * aligned_alloc_array(size_t size, size_t alignment = CACHELINE_SIZE) {
+  printf("in %s\n", __FUNCTION__ );
+  return new (std::align_val_t(alignment)) AllocType[size];
+}
+
+void * aligned_alloc_chunk(size_t size, size_t alignment = CACHELINE_SIZE) {
+  printf("in %s\n", __FUNCTION__ );
+  return new (std::align_val_t(alignment)) char[size];
+}
+
+template<typename AllocType>
+AllocType * aligned_free(AllocType * ptr) {
+  printf("in %s\n", __FUNCTION__ );
+  delete ptr;
+}
+
+template<typename AllocType>
+AllocType * aligned_free_array(AllocType * ptr) {
+  printf("in %s\n", __FUNCTION__ );
+  delete[] ptr;
+}
+
+void aligned_free_chunk(void * ptr) {
+  printf("in %s\n", __FUNCTION__ );
+  auto * chunk =reinterpret_cast<char *>(ptr);
+  delete[] chunk;
+}
+
+}
+
+#endif //LOMP_MEMORY_H

--- a/src/memory.h
+++ b/src/memory.h
@@ -45,7 +45,7 @@ inline void * make_aligned_chunk(size_t size) {
 template<typename AllocType>
 inline void delete_aligned(AllocType * ptr) {
   debug(Debug::MemoryAllocation,
-        "dealloction of pointer %p via %s()",
+        "deallocation of pointer %p via %s()",
         ptr, __FUNCTION__);
   delete ptr;
 }
@@ -53,14 +53,14 @@ inline void delete_aligned(AllocType * ptr) {
 template<typename AllocType>
 inline void delete_aligned_struct(AllocType * ptr) {
   debug(Debug::MemoryAllocation,
-        "dealloction of pointer %p via %s()",
+        "deallocation of pointer %p via %s()",
         ptr, __FUNCTION__);
   delete ptr;
 }
 
 inline void delete_aligned_chunk(void * ptr) {
   debug(Debug::MemoryAllocation,
-        "dealloction of pointer %p via %s()",
+        "deallocation of pointer %p via %s()",
         ptr, __FUNCTION__);
   auto * chunk = reinterpret_cast<char *>(ptr);
   delete[] chunk;

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,6 +1,10 @@
+//===-- memory.h - LOMP Memory Allocation Interfaces ------------*- C++ -*-===//
 //
-// Created by micha on 19.02.2022.
+// Part of the LOMP project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
 
 #ifndef LOMP_MEMORY_H
 #define LOMP_MEMORY_H

--- a/src/memory.h
+++ b/src/memory.h
@@ -51,6 +51,8 @@ inline void delete_aligned_chunk(void * ptr) {
 }
 
 struct CacheAligned {
+    static const auto alignment = CACHELINE_SIZE;
+
     void * operator new(std::size_t sz) {
       fprintf(stderr, "new at %s:%d\n", __FILE__, __LINE__);
       return make_aligned_chunk(sz);

--- a/src/numa_support.cc
+++ b/src/numa_support.cc
@@ -65,7 +65,7 @@ void InitializeNumaSupport() {
     NumberOfCores = numa_num_configured_cpus();
   }
   else {
-    debug(DebugLevel, "NUMA: libnuma reported -1 for it's API.  Defaulting to single NUMA domain.");
+    debug(DebugLevel, "NUMA: libnuma reported -1 for its API.  Defaulting to single NUMA domain.");
     NumberOfNumaDomains = 1;
     NumberOfCores = std::thread::hardware_concurrency();
   }

--- a/src/tasking.cc
+++ b/src/tasking.cc
@@ -317,7 +317,7 @@ TaskPool * TaskPoolFactory() {
   pool = &taskPool;
 #endif
 #if USE_MULTI_TASK_POOL
-  pool = new TaskPool{};
+  pool = memory::make_aligned_struct<TaskPool>();
 #endif
 #if DEBUG_TASKING
   printf("task pool factory, task pool %p\n", pool);
@@ -776,7 +776,7 @@ void TaskgroupBegin() {
   auto thread = Thread::getCurrentThread();
   auto outer = thread->getCurrentTaskgroup();
 
-  auto inner = new Taskgroup(outer);
+  auto * inner = memory::make_aligned_struct<Taskgroup>(outer);
   thread->setCurrentTaskgroup(inner);
 
 #if DEBUG_TASKING

--- a/src/tasking.cc
+++ b/src/tasking.cc
@@ -210,19 +210,14 @@ struct TaskPoolLinkedListLIFO {
 #endif
 
 private:
-  struct ListNode {
+  struct ListNode : private memory::CacheAligned {
+    ListNode(ListNode * next_, TaskDescriptor * task_) : next(next_), task(task_) {}
+
     ListNode * next;
     TaskDescriptor * task;
 
-    void * operator new(std::size_t sz) {
-      fprintf(stderr, "new at %s:%d\n", __FILE__, __LINE__);
-      return memory::make_aligned_chunk(sz);
-    }
-
-    void operator delete(void * ptr) {
-      fprintf(stderr, "delete at %s:%d\n", __FILE__, __LINE__);
-      memory::delete_aligned_chunk(ptr);
-    }
+    using CacheAligned::operator new;
+    using CacheAligned::operator delete;
   };
   ListNode * head;
   size_t taskCount;
@@ -288,19 +283,14 @@ struct TaskPoolRestrictedLinkedListLIFO {
 #endif
 
 private:
-  struct ListNode {
+  struct ListNode : private memory::CacheAligned {
+    ListNode(ListNode * next_, TaskDescriptor * task_) : next(next_), task(task_) {}
+
     ListNode * next;
     TaskDescriptor * task;
 
-    void * operator new(std::size_t sz) {
-      fprintf(stderr, "new at %s:%d\n", __FILE__, __LINE__);
-      return memory::make_aligned_chunk(sz);
-    }
-
-    void operator delete(void * ptr) {
-      fprintf(stderr, "delete at %s:%d\n", __FILE__, __LINE__);
-      memory::delete_aligned_chunk(ptr);
-    }
+    using CacheAligned::operator new;
+    using CacheAligned::operator delete;
   };
   ListNode * head;
   size_t taskCount;

--- a/src/tasking.cc
+++ b/src/tasking.cc
@@ -19,6 +19,7 @@
 
 #include "debug.h"
 
+#include "memory.h"
 #include "tasking.h"
 #include "threads.h"
 #include "numa_support.h"
@@ -343,9 +344,9 @@ size_t ComputeAllocSize(size_t sizeOfTaskClosure, size_t sizeOfShareds) {
 
 TaskDescriptor * AllocateTask(size_t sizeOfTaskClosure, size_t sizeOfShareds) {
   auto allocSize = ComputeAllocSize(sizeOfTaskClosure, sizeOfShareds);
-  auto task = static_cast<TaskDescriptor *>(malloc(allocSize));
+  auto * task = static_cast<TaskDescriptor *>(memory::aligned_alloc_chunk(allocSize));
   if (!task) {
-    // TODO: handle this error
+    lomp::fatalError("Could not allocate %d bytes for task descriptor", allocSize);
   }
 #if DEBUG_TASKING
   memset(static_cast<void *>(task), 0, allocSize);
@@ -440,7 +441,7 @@ bool StoreTask(TaskDescriptor * task) {
 
 void FreeTask(TaskDescriptor * task) {
   // memset(task, 0, sizeof(TaskDescriptor));
-  free(task);
+  memory::aligned_free_chunk(task);
 }
 
 void FreeTaskAndAncestors(TaskDescriptor * task) {


### PR DESCRIPTION
Introduce memory allocation functions `make_aligned`, `make_aligned_struct`, and `make_aligned_chunk` (plus their deallocation counterparts) to perform memory allocations that are aligned to `CACHELINE_SIZE` (see `target.h`) bytes.

Resolves issue #7.