### PR TITLE
Initial fix for issue 6 (improved nonmonotonic scheduling).

### DIFF
--- a/microBM/test_tracer.cc
+++ b/microBM/test_tracer.cc
@@ -11,6 +11,14 @@
 
 #include <omp.h>
 #include <cstdio>
+
+// Force DEBUG here, since this is a test for code that is only
+// compiled when DEBUG is enabled. It is useful to be able to run the
+// test even if the CMAKE-ery does not enable DEBUG!
+#if (defined(DEBUG))
+#undef DEBUG
+#endif
+
 #define DEBUG 1
 #include "event-trace.h"
 

--- a/microBM/test_tracer.cc
+++ b/microBM/test_tracer.cc
@@ -11,7 +11,7 @@
 
 #include <omp.h>
 #include <cstdio>
-#define EVENT_TRACE_ENABLED 1
+#define DEBUG 1
 #include "event-trace.h"
 
 int main(int, char **) {

--- a/src/barrier_impl.cc
+++ b/src/barrier_impl.cc
@@ -470,8 +470,7 @@ public:
 // (Need to use "after" for the comparison to avoid overflow issues...)
 
 // A barrier in which threads count up or down, polling the appropriate counter.
-class AtomicUpDownBarrier : public Barrier,
-                            private memory::CacheAligned {
+class AtomicUpDownBarrier : public Barrier, private memory::CacheAligned {
   enum { MAX_THREADS = 64 };
   AtomicUpDownCounter counters[2];
   AlignedUint32 barrierCounts[MAX_THREADS];
@@ -832,8 +831,7 @@ public:
  * in the LBW broadcast, we can rapidly produce many many barriers!
  */
 template <class counter, class broadcast, char const * fullName>
-class centralizedBarrier : public Barrier,
-                           private memory::CacheAligned {
+class centralizedBarrier : public Barrier, private memory::CacheAligned {
   counter CheckedIn;
   broadcast Broadcast;
 
@@ -981,8 +979,7 @@ FOREACH_DYNAMICTREE_BARRIER(EXPAND_DYNAMICTREE_BARRIER, LBWBroadcast<4>, LBW4)
 // An all to all barrier. We use an atomic counter on each thread
 // We could equally make this into a template and use our other, flag
 // counter here, though that would make the barrier quite large.
-class AllToAllAtomicBarrier : public Barrier,
-                              private memory::CacheAligned {
+class AllToAllAtomicBarrier : public Barrier, private memory::CacheAligned {
   enum { MAX_THREADS = 64 };
   uint32_t NumThreads;
   AlignedAtomicUint32 flags[2][MAX_THREADS];
@@ -1047,8 +1044,7 @@ public:
 // be used to build dissemination or hypercube barriers.
 // Or, probably others too.
 template <int radix>
-class distributedLogBarrier : public Barrier,
-                              private memory::CacheAligned {
+class distributedLogBarrier : public Barrier, private memory::CacheAligned {
 
   // We want the derived class to be able to see into here since it
   // needs access to things like the number of threads and rounds.

--- a/src/debug.h
+++ b/src/debug.h
@@ -14,7 +14,7 @@
 
 #include "globals.h"
 
-/// Check \p cond and aborts if it is not true.
+/// Checks \p cond and aborts if it is not true.
 #define LOMP_ASSERT(cond)                                                      \
   do {                                                                         \
     if (UNLIKELY(!(cond))) {                                                   \
@@ -39,11 +39,11 @@ enum Debug {
   Info = 2, /* NUMA info and so on. */
   Detailed = 10,
   // Switch around when debugging specific subsystems so that you can get info from only the subsystem you want.
-  Reduction = 15,
-  Threads = 20,
-  MemoryAllocation = 30,
-  Barriers = 40,
-  Loops = 50,
+  Loops = 15,
+  Reduction = 20,
+  Threads = 30,
+  MemoryAllocation = 40,
+  Barriers = 50,
   Locks = 60,
   Functions = 1000,
 };

--- a/src/entrypoints.cc
+++ b/src/entrypoints.cc
@@ -28,7 +28,8 @@ extern "C" {
 int32_t omp_get_thread_num(void) {
   lomp::Thread * Me = lomp::Thread::getCurrentThread();
 
-  return Me->getTeam()->inParallel() ? static_cast<int32_t>(Me->getLocalId()) : 0;
+  return Me->getTeam()->inParallel() ? static_cast<int32_t>(Me->getLocalId())
+                                     : 0;
 }
 
 int32_t omp_get_num_threads(void) {
@@ -101,8 +102,9 @@ void omp_display_env(int verbose) {
   if (!lomp::RuntimeInitialized) {
     lomp::initializeRuntime();
   }
-  lomp::displayEnvironment(verbose ? lomp::displayVerbosity::verbose /* all ICVs */
-                                   : lomp::displayVerbosity::enabled /* OpenMP ICVs */);
+  lomp::displayEnvironment(
+      verbose ? lomp::displayVerbosity::verbose /* all ICVs */
+              : lomp::displayVerbosity::enabled /* OpenMP ICVs */);
 }
 
 // Functions called by the compiler itself.
@@ -231,9 +233,8 @@ void __kmpc_flush(ident_t *) {
 // Tasking interfaces
 void * __kmpc_omp_task_alloc(ident_t *, // where
                              int32_t,   // gtid
-                             int32_t flags,
-                             size_t sizeOfTaskClosure, size_t sizeOfShareds,
-                             void * thunkPtr) {
+                             int32_t flags, size_t sizeOfTaskClosure,
+                             size_t sizeOfShareds, void * thunkPtr) {
   if (flags != 1) {
     // We do not support anything like untied, final, mergeable, etc.
     lomp::fatalError("LOMP does not support advanced task features, "

--- a/src/environment.cc
+++ b/src/environment.cc
@@ -84,8 +84,7 @@ bool getStringWithIntArgument(char const * var,
     int num = stoi(tmp.second);
     value = std::make_pair(str, num);
     result = true;
-  }
-  catch (...) {
+  } catch (...) {
     value = def;
     result = false;
   }

--- a/src/event-trace.h
+++ b/src/event-trace.h
@@ -69,10 +69,10 @@ public:
   ~eventTracer() {}
 
   void reset() {
-    for (int i=0; i<numEvents; i++)
+    for (int i = 0; i < numEvents; i++)
       events[i].release();
   }
-  
+
   void insertEvent(char const * f, ...) {
     va_list args;
     va_start(args, f);

--- a/src/event-trace.h
+++ b/src/event-trace.h
@@ -68,6 +68,11 @@ public:
   eventTracer() : nextEvent(0), locked(false) {}
   ~eventTracer() {}
 
+  void reset() {
+    for (int i=0; i<numEvents; i++)
+      events[i].release();
+  }
+  
   void insertEvent(char const * f, ...) {
     va_list args;
     va_start(args, f);

--- a/src/globals.cc
+++ b/src/globals.cc
@@ -45,8 +45,9 @@ void displayEnvironmentVariable(const std::string & name) {
 }
 
 void displayEnvironment(displayVerbosity verbosity) {
-  auto standardDisplay = {"OMP_NUM_THREADS","OMP_SCHEDULE", "OMP_DISPLAY_ENV"};
-  auto verboseDisplay = {"LOMP_LOCK_KIND", "LOMP_BARRIER_KIND", "LOMP_DEBUG", "LOMP_TRACE"};
+  auto standardDisplay = {"OMP_NUM_THREADS", "OMP_SCHEDULE", "OMP_DISPLAY_ENV"};
+  auto verboseDisplay = {"LOMP_LOCK_KIND", "LOMP_BARRIER_KIND", "LOMP_DEBUG",
+                         "LOMP_TRACE"};
   printf("OPENMP DISPLAY ENVIRONMENT\n");
   printf("  _OPENMP='%d'\n", 0);
   for (auto var : standardDisplay) {

--- a/src/interface.h
+++ b/src/interface.h
@@ -111,8 +111,8 @@ typedef enum sched_type : int32_t {
 #define SCHEDULE_HAS_NO_MODIFIERS(s)                                           \
   (((s) & (kmp_sch_modifier_nonmonotonic | kmp_sch_modifier_monotonic)) == 0)
 #define SCHEDULE_GET_MODIFIERS(s)                                              \
-  ((enum sched_type)((s) & (kmp_sch_modifier_nonmonotonic |                    \
-                            kmp_sch_modifier_monotonic)))
+  ((enum sched_type)(                                                          \
+      (s) & (kmp_sch_modifier_nonmonotonic | kmp_sch_modifier_monotonic)))
 } kmp_sched_t;
 
 extern "C" {

--- a/src/locks.cc
+++ b/src/locks.cc
@@ -38,7 +38,7 @@ namespace lomp::locks {
 // Note that this meets the requirements of the C++ "Lockable"
 // https://en.cppreference.com/w/cpp/named_req/Lockable ;
 // therefore it can be used behind std::lock_guard if required.
-class abstractLock {  // TODO: should this be aligned to a cache line?
+class abstractLock { // TODO: should this be aligned to a cache line?
 public:
   abstractLock() {}
   virtual ~abstractLock() {}

--- a/src/loops.h
+++ b/src/loops.h
@@ -167,11 +167,12 @@ class contiguousWork {
   auto setEnd(unsignedType e, std::memory_order order) {
     return ab.atomicEnd.store(e, order);
   }
+
 public:
   contiguousWork() {}
   contiguousWork(unsignedType b, unsignedType e)
       : stealing(false), iterationsStarted(0) {
-    assign(b,e);
+    assign(b, e);
   }
   contiguousWork(contiguousWork * other) {
     // N.B. NOT loaded atomically over both parts, but that's fine, since when we update
@@ -194,7 +195,7 @@ public:
   void assign(unsignedType b, unsignedType e) {
     // No need for atomicity here; we're copying into a local value.
     ab.atomicBase.store(b, std::memory_order_relaxed);
-    ab.atomicEnd.store (e, std::memory_order_relaxed);
+    ab.atomicEnd.store(e, std::memory_order_relaxed);
   }
   void zeroStarted() {
     iterationsStarted.store(0, std::memory_order_release);
@@ -215,7 +216,7 @@ public:
   }
   // Only the owning thread modifies the started field so this need not be atomic.
   void incrStarted() {
-    iterationsStarted.store(getStarted()+1, std::memory_order_release);
+    iterationsStarted.store(getStarted() + 1, std::memory_order_release);
   }
 };
 

--- a/src/loops.h
+++ b/src/loops.h
@@ -138,30 +138,19 @@ class contiguousWork {
   // canonical form it represents one iteration (with value zero).
   // Less than is more convenient here, since the empty (0,0) case can occur, and it
   // is hard to represent in the canonical form.
-  typedef struct {
-    // We need the compiler to realise that these may be updated at any time, so
-    // they have to be atomic types, even if we don't always need the atomic
-    // operations.
-    std::atomic<unsignedType> base; // Only written by the owner, so
-                                    // operations (such as ++) do not
-                                    // need to be atomic, all we need
-                                    // to ensure is that there is no
-                                    // tearing and that ordering is
-                                    // correct.
-    std::atomic<unsignedType> end;  // Can be written by any of the
-                                    // other threads when they are
-                                    // stealing work.
-  } bounds_t;
-
+  // N.B. The bounds here are based on a "less than" calculation, unlike the canonical
+  // bounds which use <=. Therefore here (0,0) represents no iterations, whereas in the
+  // canonical form it represents one iteration (with value zero).
+  // Less than is more convenient here, since the empty (0,0) case can occur, and it
+  // is hard to represent in the canonical form.
   union CACHE_ALIGNED {
+    // For some reason GCC requires that we name the struct, while LLVM is happy
+    // for it to be anonymous, so we name it, and then have to type a little more
+    // in a few places.
     struct {
       std::atomic<unsignedType> atomicBase;
       std::atomic<unsignedType> atomicEnd;
-    };
-    struct {
-      unsignedType base;
-      unsignedType end;
-    };
+    } ab;
     pairType pair;
     std::atomic<pairType> atomicPair;
   };
@@ -172,40 +161,46 @@ class contiguousWork {
   // Number of iterations this thread has started to execute. (One may still be in flight).
   std::atomic<unsignedType> iterationsStarted;
 
-  auto setBase(unsignedType nb) {
-    return atomicBase.store(nb, std::memory_order_release);
+  auto setBase(unsignedType b, std::memory_order order) {
+    return ab.atomicBase.store(b, order);
   }
-
+  auto setEnd(unsignedType e, std::memory_order order) {
+    return ab.atomicEnd.store(e, order);
+  }
 public:
   contiguousWork() {}
   contiguousWork(unsignedType b, unsignedType e)
       : stealing(false), iterationsStarted(0) {
-    base = b;
-    end = e;
+    assign(b,e);
   }
   contiguousWork(contiguousWork * other) {
     // N.B. NOT loaded atomically over both parts, but that's fine, since when we update
     // we'll use a wide CAS, so if it changed at all we'll see it.
-    base = other->getBase();
-    end = other->getEnd();
+    assign(other->getBase(), other->getEnd());
   }
   ~contiguousWork() {}
 
+  auto getBase(std::memory_order order = std::memory_order_acquire) const {
+    return ab.atomicBase.load(order);
+  }
+  auto getEnd(std::memory_order order = std::memory_order_acquire) const {
+    return ab.atomicEnd.load(order);
+  }
   auto getIterations() const {
     return getEnd() - getBase();
   }
-  auto getBase() const {
-    return atomicBase.load(std::memory_order_acquire);
-  }
-  auto getEnd() const {
-    return atomicEnd.load(std::memory_order_acquire);
-  }
+  void initializeBalanced(unsignedType count, uint32_t thread,
+                          uint32_t numThreads);
   void assign(unsignedType b, unsignedType e) {
-    // No need for atomicity here.
-    base = b;
-    end = e;
+    // No need for atomicity here; we're copying into a local value.
+    ab.atomicBase.store(b, std::memory_order_relaxed);
+    ab.atomicEnd.store (e, std::memory_order_relaxed);
   }
-
+  void zeroStarted() {
+    iterationsStarted.store(0, std::memory_order_release);
+  }
+  bool trySteal(unsignedType * basep, unsignedType * endp);
+  bool incrementBase(unsignedType * oldp);
   auto isStealing() const {
     return stealing.load(std::memory_order_acquire);
   }
@@ -218,16 +213,10 @@ public:
   auto getStarted() const {
     return iterationsStarted.load(std::memory_order_acquire);
   }
+  // Only the owning thread modifies the started field so this need not be atomic.
   void incrStarted() {
-    iterationsStarted.fetch_add(1, std::memory_order_release);
+    iterationsStarted.store(getStarted()+1, std::memory_order_release);
   }
-  void zeroStarted() {
-    iterationsStarted.store(0, std::memory_order_release);
-  }
-  void initializeBalanced(unsignedType count, uint32_t thread,
-                          uint32_t numThreads);
-  bool trySteal(unsignedType * basep, unsignedType * endp);
-  bool incrementBase(unsignedType * oldp);
 };
 
 // The packed, non-template, version so that we can put one into each thread.

--- a/src/memory.h
+++ b/src/memory.h
@@ -16,66 +16,62 @@
 
 namespace lomp::memory {
 
-template<typename AllocType, typename... Args>
-inline AllocType * make_aligned(Args&&... args) {
-  auto * ptr = new (std::align_val_t(CACHELINE_SIZE)) AllocType(std::forward<Args>(args)...);
-  debug(Debug::MemoryAllocation,
-        "aligned allocation of %zu bytes at %p via %s",
+template <typename AllocType, typename... Args>
+inline AllocType * make_aligned(Args &&... args) {
+  auto * ptr = new (std::align_val_t(CACHELINE_SIZE))
+      AllocType(std::forward<Args>(args)...);
+  debug(Debug::MemoryAllocation, "aligned allocation of %zu bytes at %p via %s",
         sizeof(AllocType), ptr, __FUNCTION__);
   return ptr;
 }
 
-template<typename AllocType, typename... Args>
-inline AllocType * make_aligned_struct(Args&&... args) {
-  auto * ptr = new (std::align_val_t(CACHELINE_SIZE)) AllocType{std::forward<Args>(args)...};
-  debug(Debug::MemoryAllocation,
-        "aligned allocation of %zu bytes at %p via %s",
+template <typename AllocType, typename... Args>
+inline AllocType * make_aligned_struct(Args &&... args) {
+  auto * ptr = new (std::align_val_t(CACHELINE_SIZE))
+      AllocType{std::forward<Args>(args)...};
+  debug(Debug::MemoryAllocation, "aligned allocation of %zu bytes at %p via %s",
         sizeof(AllocType), ptr, __FUNCTION__);
   return ptr;
 }
 
 inline void * make_aligned_chunk(size_t size) {
   auto * ptr = new (std::align_val_t(CACHELINE_SIZE)) char[size];
-  debug(Debug::MemoryAllocation,
-        "aligned allocation of %zu bytes at %p via %s",
+  debug(Debug::MemoryAllocation, "aligned allocation of %zu bytes at %p via %s",
         size, ptr, __FUNCTION__);
   return ptr;
 }
 
-template<typename AllocType>
+template <typename AllocType>
 inline void delete_aligned(AllocType * ptr) {
-  debug(Debug::MemoryAllocation,
-        "deallocation of pointer %p via %s()",
-        ptr, __FUNCTION__);
+  debug(Debug::MemoryAllocation, "deallocation of pointer %p via %s()", ptr,
+        __FUNCTION__);
   delete ptr;
 }
 
-template<typename AllocType>
+template <typename AllocType>
 inline void delete_aligned_struct(AllocType * ptr) {
-  debug(Debug::MemoryAllocation,
-        "deallocation of pointer %p via %s()",
-        ptr, __FUNCTION__);
+  debug(Debug::MemoryAllocation, "deallocation of pointer %p via %s()", ptr,
+        __FUNCTION__);
   delete ptr;
 }
 
 inline void delete_aligned_chunk(void * ptr) {
-  debug(Debug::MemoryAllocation,
-        "deallocation of pointer %p via %s()",
-        ptr, __FUNCTION__);
+  debug(Debug::MemoryAllocation, "deallocation of pointer %p via %s()", ptr,
+        __FUNCTION__);
   auto * chunk = reinterpret_cast<char *>(ptr);
   delete[] chunk;
 }
 
 struct CacheAligned {
-    static const auto alignment = CACHELINE_SIZE;
+  static const auto alignment = CACHELINE_SIZE;
 
-    void * operator new(std::size_t sz) {
-      return make_aligned_chunk(sz);
-    }
+  void * operator new(std::size_t sz) {
+    return make_aligned_chunk(sz);
+  }
 
-    void operator delete(void * ptr) {
-      delete_aligned_chunk(ptr);
-    }
+  void operator delete(void * ptr) {
+    delete_aligned_chunk(ptr);
+  }
 };
 
 } // namespace lomp::memory

--- a/src/numa_support.cc
+++ b/src/numa_support.cc
@@ -57,7 +57,7 @@ void DumpNumaDatabase() {
 void InitializeNumaSupport() {
   debug(DebugLevel, "NUMA: Initializing NUMA support.");
   bool available = false;
-  
+
 #if (LOMP_HAVE_LIBNUMA)
   available = numa_available() != -1;
   if (available) {
@@ -65,7 +65,8 @@ void InitializeNumaSupport() {
     NumberOfCores = numa_num_configured_cpus();
   }
   else {
-    debug(DebugLevel, "NUMA: libnuma reported -1 for its API.  Defaulting to single NUMA domain.");
+    debug(DebugLevel, "NUMA: libnuma reported -1 for its API.  Defaulting to "
+                      "single NUMA domain.");
     NumberOfNumaDomains = 1;
     NumberOfCores = std::thread::hardware_concurrency();
   }

--- a/src/stats-timing.cc
+++ b/src/stats-timing.cc
@@ -124,8 +124,8 @@ std::string CPUModelName() {
     char line[256];
     while (fgets(&line[0], sizeof(line), f) != nullptr) {
       if (strncmp("model name\t: ", &line[0], 13) == 0) {
-	fclose(f);
-	return std::string(&line[13]);
+        fclose(f);
+        return std::string(&line[13]);
       }
     }
     fclose(f);
@@ -141,7 +141,7 @@ std::string CPUModelName() {
     return LOMP_TARGET_ARCH_NAME;
   }
 #endif /* Operating systems */
-#if (LOMP_TARGET_ARCH_AARCH64)  
+#if (LOMP_TARGET_ARCH_AARCH64)
   // Try the AArch64 MIDR_EL1 register; we might be able to work it out from there.
   // https://developer.arm.com/documentation/ddi0595/2020-12/AArch64-Registers/MIDR-EL1--Main-ID-Register
   struct EL1 {
@@ -185,7 +185,7 @@ std::string CPUModelName() {
 
   // RISC-V may also have some trickery; Google Is Your Friend...
   return LOMP_TARGET_ARCH_NAME;
-#endif  
+#endif
 }
 #endif /* LOMP_TARGET_ARCH_X86_64 */
 } // namespace Target

--- a/src/target_riscv.h
+++ b/src/target_riscv.h
@@ -45,7 +45,7 @@ inline std::uint64_t readCycleCount() {
 #if __riscv_xlen != 64
 #warning "Function readCycleCount() not implemented for RISC-V 32-bit"
 #else
-  __asm__ volatile ("rdcycle %0": "=r"(res));
+  __asm__ volatile("rdcycle %0" : "=r"(res));
 #endif
   return res;
 }

--- a/src/tasking.cc
+++ b/src/tasking.cc
@@ -211,7 +211,8 @@ struct TaskPoolLinkedListLIFO {
 
 private:
   struct ListNode : private memory::CacheAligned {
-    ListNode(ListNode * next_, TaskDescriptor * task_) : next(next_), task(task_) {}
+    ListNode(ListNode * next_, TaskDescriptor * task_)
+        : next(next_), task(task_) {}
 
     ListNode * next;
     TaskDescriptor * task;
@@ -284,7 +285,8 @@ struct TaskPoolRestrictedLinkedListLIFO {
 
 private:
   struct ListNode : private memory::CacheAligned {
-    ListNode(ListNode * next_, TaskDescriptor * task_) : next(next_), task(task_) {}
+    ListNode(ListNode * next_, TaskDescriptor * task_)
+        : next(next_), task(task_) {}
 
     ListNode * next;
     TaskDescriptor * task;
@@ -359,9 +361,11 @@ size_t ComputeAllocSize(size_t sizeOfTaskClosure, size_t sizeOfShareds) {
 
 TaskDescriptor * AllocateTask(size_t sizeOfTaskClosure, size_t sizeOfShareds) {
   auto allocSize = ComputeAllocSize(sizeOfTaskClosure, sizeOfShareds);
-  auto * task = static_cast<TaskDescriptor *>(memory::make_aligned_chunk(allocSize));
+  auto * task =
+      static_cast<TaskDescriptor *>(memory::make_aligned_chunk(allocSize));
   if (!task) {
-    lomp::fatalError("Could not allocate %d bytes for task descriptor", allocSize);
+    lomp::fatalError("Could not allocate %d bytes for task descriptor",
+                     allocSize);
   }
 #if DEBUG_TASKING
   memset(static_cast<void *>(task), 0, allocSize);
@@ -431,7 +435,7 @@ void PrepareTask(TaskDescriptor * task) {
     assert(task->metadata.thread->childTasks.load() >= 0);
     task->metadata.thread->childTasks++;
   }
- 
+
   // Now we have to also record this task as active for a potentially active
   // taskgroup
   if (auto * taskgroup = task->metadata.taskgroup; taskgroup) {
@@ -442,11 +446,12 @@ void PrepareTask(TaskDescriptor * task) {
 
 bool StoreTask(TaskDescriptor * task) {
   auto * taskPool = Thread::getCurrentThread()->getTaskPool();
-  
+
   // Try to put the task into the pool.
   if (taskPool->put(task)) {
     return true;
-  } else {
+  }
+  else {
     // There was no free slot in the task pool. Execute the task immediately,
     // to avoid a stall of execution.
     InvokeTask(task);

--- a/src/tasking.h
+++ b/src/tasking.h
@@ -45,7 +45,7 @@ struct TaskDescriptor {
     /* task descriptor for task management */
     Flags flags;
     TaskDescriptor * parent; /* pointer to the parent that created this task */
-    Thread * thread; /* pointer to the thread that create the task */
+    Thread * thread;         /* pointer to the thread that create the task */
     std::atomic<int>
         childTasks; /* number of child tasks to (potentially) wait for */
     Taskgroup * taskgroup;

--- a/src/util.cc
+++ b/src/util.cc
@@ -81,7 +81,7 @@ void errPrintf(char const * Format, ...) {
     va_start(VarArgs, Format);
     Tracer->insertEvent(Format, VarArgs);
     va_end(VarArgs);
-    // No need to output the trace explicitly, since we have an atexit() hook.
+    Tracer->output(stderr);
   }
   abort();
 }

--- a/tests/test_scheduling.cc
+++ b/tests/test_scheduling.cc
@@ -106,9 +106,9 @@ static bool runLoop(char const * name, omp_sched_t schedule, int base, int end,
   int failures = 0;
   auto numThreads = omp_get_max_threads();
   int counts[numThreads];
-  for (auto i=0; i<numThreads; i++)
+  for (auto i = 0; i < numThreads; i++)
     counts[i] = 0;
-  
+
 #pragma omp parallel
   {
     int me = omp_get_thread_num();
@@ -119,7 +119,7 @@ static bool runLoop(char const * name, omp_sched_t schedule, int base, int end,
       for (int i = base; i < end; i += incr) {
         if (debug)
           fprintf(stderr, "%d: i == %d\n", me, i);
-	counts[me]++;
+        counts[me]++;
         int prev = referenced.lookup(i);
         if (prev != -1) {
           fprintf(stderr, "  index %d executed by %d AND %d\n", i, prev, me);
@@ -134,7 +134,7 @@ static bool runLoop(char const * name, omp_sched_t schedule, int base, int end,
       for (int i = base; i > end; i += incr) {
         if (debug)
           fprintf(stderr, "%d: i == %d\n", me, i);
-	counts[me]++;
+        counts[me]++;
         auto prev = referenced.lookup(i);
         if (prev != -1) {
           fprintf(stderr, "  index %d executed by %d AND %d\n", i, prev, me);
@@ -150,16 +150,16 @@ static bool runLoop(char const * name, omp_sched_t schedule, int base, int end,
           chunk, base, (incr < 0 ? '>' : '<'), end, incr,
           failures ? "***FAILED***" : "OK");
 
-  printf ("Thread, Count\n");
+  printf("Thread, Count\n");
   int total = 0;
-  for (auto i=0; i<numThreads; i++) {
+  for (auto i = 0; i < numThreads; i++) {
     total += counts[i];
   }
-  for (auto i=0; i<numThreads; i++) {
-    printf("  %4d,  %4d (%5.1f%%)\n", i, counts[i], (100.*counts[i])/total);
+  for (auto i = 0; i < numThreads; i++) {
+    printf("  %4d,  %4d (%5.1f%%)\n", i, counts[i], (100. * counts[i]) / total);
   }
   if (failures != 0 && tracingEnabled) {
-    exit(-1);  // We want to get out soon so that the trace is not owverwritten.
+    exit(-1); // We want to get out soon so that the trace is not owverwritten.
     // The trace handler has an atexit() call so will print when we exit.
   }
 
@@ -187,7 +187,7 @@ static struct scheduleInfo {
     {"guided", omp_sched_guided},
     {"monotonic:guided", omp_sched_t(omp_sched_guided | omp_sched_monotonic)},
     {"dynamic", omp_sched_dynamic}, /* == nonmonotonic:dynamic */
-    {"monotonic:dynamic", omp_sched_t(omp_sched_dynamic | omp_sched_monotonic)}, 
+    {"monotonic:dynamic", omp_sched_t(omp_sched_dynamic | omp_sched_monotonic)},
     /* hack for testing: all iterations allocated to thread zero, then behave as nonmnotonic */
     {"imbalanced", omp_sched_t(32)},
 };
@@ -199,7 +199,9 @@ static int testSchedule(scheduleInfo * sch) {
   for (int i = 0; i < nLoops; i++) {
     auto loop = &loops[i];
     failures += runLoop(sch->name, sch->schedule, loop->base, loop->end,
-			loop->incr, loop->chunk) ? 1:0;
+                        loop->incr, loop->chunk)
+                    ? 1
+                    : 0;
   }
 
   return failures;

--- a/tests/test_tasks_if0.c
+++ b/tests/test_tasks_if0.c
@@ -18,7 +18,7 @@ int main(void) {
 #pragma omp master
   {
     for (int i = 0; i < NTASKS; i++) {
-#pragma omp task shared(count) if(0)
+#pragma omp task shared(count) if (0)
       {
 #pragma omp atomic
         count++;


### PR DESCRIPTION
Improve the scheduling code for dealing with the "static steal" scheduling implementation (used for `nonmonotonic:dynamic` schedules).
This change fixes two problems:

1. The existing code failed to compile with g++ (it doesn't like a `std::atomic` data member inside an unnamed struct/union).
2. Fix the `incrementBase` function to use a `std::memory_model::seq_cst` store when updating the base. This is needed to prevent the load of the end from floating above the store, and thus providing no  ability to detect the race which it is used to detect.

With this fix the code passes test onX86_64 (where it previously failed), and one can see that the change to the requested memory model has affected the generated code (introducing the use of an `xchg` instruction [which is always atomic on X86] instead of a simple store).  On AARCH64 there is no change, since it already used `ldar` and `strl` instructions which synchronize with each otehr,